### PR TITLE
Fix osu! stats, enrich profile header, add Steam level and top games

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,11 +13,12 @@ const app = new Hono<{ Bindings: Bindings }>()
 export type SteamResult = {
     totalHours: number,
     totalPlaytime: number,
-    topGames: string[],
+    gameCount: number,
+    topGames: { name: string, hours: number }[],
     lastPlayedGame: {
         name: string,
         lastPlayed: number
-    }
+    } | null
 }
 
 export type OsuResult = {
@@ -34,6 +35,10 @@ export type OsuResult = {
     playCount: number,
     playTime: number,
     maxCombo: number,
+    followerCount: number,
+    joinDate: string | null,
+    rankedScore: number,
+    title: string | null,
 }
 
 app.use(cors())
@@ -54,7 +59,16 @@ async function getOsuToken(env: Bindings): Promise<string> {
         })
     })
 
+    if (!response.ok) {
+        const errBody = await response.text()
+        throw new Error(`osu! OAuth failed (${response.status}): ${errBody}`)
+    }
+
     const data = await response.json() as { access_token: string, expires_in: number }
+    if (!data.access_token) {
+        throw new Error(`osu! OAuth: missing access_token in response`)
+    }
+
     await env.KV.put(CACHE_KEY, data.access_token, { expirationTtl: data.expires_in - 60 })
     return data.access_token
 }
@@ -97,6 +111,10 @@ app.get('/my-osu', async (c) => {
         playCount: data.statistics?.play_count ?? 0,
         playTime: data.statistics?.play_time ?? 0,
         maxCombo: data.statistics?.maximum_combo ?? 0,
+        followerCount: data.follower_count ?? 0,
+        joinDate: data.join_date ?? null,
+        rankedScore: data.statistics?.ranked_score ?? 0,
+        title: data.title ?? null,
     }
 
     await c.env.KV.put(CACHE_KEY, JSON.stringify(result), { expirationTtl: CACHE_DURATION })
@@ -104,11 +122,10 @@ app.get('/my-osu', async (c) => {
 })
 
 app.get('/my-steam', async (c) => {
-    const CACHE_KEY = "steam:profile"
+    const CACHE_KEY = "steam:profile:v2"
     const CACHE_DURATION = 3600;
 
     const cachedRes = await c.env.KV.get<SteamResult>(CACHE_KEY, { type: "json" })
-
     if (cachedRes) {
         return c.json(cachedRes)
     }
@@ -120,10 +137,7 @@ app.get('/my-steam', async (c) => {
     const response = await fetch(apiUrl);
 
     if (!response.ok) {
-        return c.json({
-            error: true,
-            status: response.status,
-        })
+        return c.json({ error: true, status: response.status })
     }
 
     const data = await response.json() as any;
@@ -143,13 +157,16 @@ app.get('/my-steam', async (c) => {
         return latest;
     }, null);
 
-    const topGames = games
-        .sort((a: any, b: any) => (b.playtime_forever || 0) - (a.playtime_forever || 0))
-        .map((game: any) => game.name);
+    const sorted = games.sort((a: any, b: any) => (b.playtime_forever || 0) - (a.playtime_forever || 0));
 
-    const result = {
+    const topGames = sorted
+        .slice(0, 3)
+        .map((game: any) => ({ name: game.name, hours: Math.round((game.playtime_forever || 0) / 60) }));
+
+    const result: SteamResult = {
         totalHours,
         totalPlaytime,
+        gameCount: games.length,
         topGames,
         lastPlayedGame: lastPlayedGame && lastPlayedGame.rtime_last_played ? {
             name: lastPlayedGame.name,

--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,23 @@
               <i class="fab fa-steam"></i> steam enjoyer
             </span>
           </div>
+          <div class="profile-meta-row" id="profile-meta-row" style="display:none;">
+            <span id="osu-title-badge" style="display:none;"></span>
+            <span class="profile-meta-item">
+              <i class="fas fa-users"></i>
+              <span id="osu-follower-count">—</span> followers
+            </span>
+            <span class="profile-meta-sep">·</span>
+            <span class="profile-meta-item">
+              <i class="fas fa-calendar-alt"></i>
+              <span id="osu-join-date">—</span>
+            </span>
+            <span class="profile-meta-sep">·</span>
+            <span class="profile-meta-item">
+              <i class="fas fa-star"></i>
+              <span id="osu-ranked-score">—</span> ranked score
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -113,7 +130,7 @@
         </a>
       </h2>
 
-      <div class="steam-stats-card">
+      <div class="steam-stats-card steam-card-top">
         <div class="steam-stat-item">
           <span class="steam-stat-value" id="steam-hours">—</span>
           <span class="steam-stat-label">Hours Gaming</span>
@@ -127,6 +144,22 @@
         <div class="steam-stat-item steam-last-played-item">
           <span class="steam-stat-value steam-last-played-name" id="steam-last-played">—</span>
           <span class="steam-stat-label" id="steam-last-played-label">Last Played</span>
+        </div>
+        <div class="steam-stat-divider"></div>
+        <div class="steam-stat-item steam-level-item">
+          <span class="steam-level-badge">
+            <span class="steam-level-number" id="steam-level-value">—</span>
+          </span>
+          <span class="steam-stat-label">Steam Level</span>
+        </div>
+      </div>
+
+      <div class="steam-top-games-card">
+        <div class="steam-top-games-header">Most Played</div>
+        <div id="steam-top-games">
+          <div class="top-game-row"><span class="top-game-rank">#1</span><span class="top-game-name loading">—</span><span class="top-game-hours loading">—</span></div>
+          <div class="top-game-row"><span class="top-game-rank">#2</span><span class="top-game-name loading">—</span><span class="top-game-hours loading">—</span></div>
+          <div class="top-game-row"><span class="top-game-rank">#3</span><span class="top-game-name loading">—</span><span class="top-game-hours loading">—</span></div>
         </div>
       </div>
     </section>

--- a/src/osu-api.js
+++ b/src/osu-api.js
@@ -19,7 +19,7 @@ async function fetchOsuStats() {
 }
 
 function renderOsuStats(data) {
-    setText('osu-global-rank', data.globalRank ? `#${data.globalRank.toLocaleString()}`.replace('#', '') : '—');
+    setText('osu-global-rank', data.globalRank ? data.globalRank.toLocaleString() : '—');
     setText('osu-country-rank', data.countryRank ? data.countryRank.toLocaleString() : '—');
     setText('osu-pp', data.pp ? data.pp.toLocaleString() : '—');
     setText('osu-accuracy', data.accuracy ? `${data.accuracy}%` : '—');
@@ -33,7 +33,7 @@ function renderOsuStats(data) {
         if (label) label.textContent = `${data.country} Rank`;
     }
 
-    // Update cover if available
+    // Update cover image with osu! profile cover
     if (data.coverUrl) {
         const cover = document.getElementById('cover-bg');
         if (cover) {
@@ -47,6 +47,29 @@ function renderOsuStats(data) {
     if (data.avatarUrl) {
         const avatar = document.getElementById('profile-avatar');
         if (avatar) avatar.src = data.avatarUrl;
+    }
+
+    // Profile meta row: follower count, join date, ranked score, title
+    const metaRow = document.getElementById('profile-meta-row');
+    if (metaRow) {
+        if (data.followerCount != null) {
+            setText('osu-follower-count', data.followerCount.toLocaleString());
+        }
+        if (data.joinDate) {
+            const formatted = new Date(data.joinDate).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+            setText('osu-join-date', `Joined ${formatted}`);
+        }
+        if (data.rankedScore) {
+            setText('osu-ranked-score', data.rankedScore.toLocaleString());
+        }
+        if (data.title) {
+            const titleEl = document.getElementById('osu-title-badge');
+            if (titleEl) {
+                titleEl.textContent = data.title;
+                titleEl.style.display = '';
+            }
+        }
+        metaRow.style.display = '';
     }
 
     removeLoading();
@@ -68,22 +91,21 @@ function setText(id, value) {
 
 function setOsuLoading(isLoading) {
     const ids = ['osu-global-rank', 'osu-country-rank', 'osu-pp', 'osu-accuracy',
-                 'osu-level', 'osu-playcount', 'osu-playtime', 'osu-maxcombo'];
+                 'osu-level', 'osu-playcount', 'osu-playtime', 'osu-maxcombo',
+                 'osu-follower-count', 'osu-join-date', 'osu-ranked-score'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) {
-            if (isLoading) {
-                el.classList.add('loading');
-            } else {
-                el.classList.remove('loading');
-            }
+            if (isLoading) el.classList.add('loading');
+            else           el.classList.remove('loading');
         }
     });
 }
 
 function setOsuError() {
     const ids = ['osu-global-rank', 'osu-country-rank', 'osu-pp', 'osu-accuracy',
-                 'osu-level', 'osu-playcount', 'osu-playtime', 'osu-maxcombo'];
+                 'osu-level', 'osu-playcount', 'osu-playtime', 'osu-maxcombo',
+                 'osu-follower-count', 'osu-join-date', 'osu-ranked-score'];
     ids.forEach(id => setText(id, '—'));
 }
 

--- a/src/steam-api.js
+++ b/src/steam-api.js
@@ -1,17 +1,22 @@
-const STEAM_ID = '76561198045384584';
+const STEAM_API_URL   = 'https://api-ice.nyannoying.workers.dev/my-steam';
+const STEAM_LEVEL_URL = 'https://api-ice.nyannoying.workers.dev/my-steam-level';
 
 async function fetchSteamGames() {
-    const apiUrl = `https://api-ice.nyannoying.workers.dev/my-steam`;
-
     try {
         setSteamLoading(true);
 
-        const response = await fetch(apiUrl);
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const [gamesRes, levelRes] = await Promise.all([
+            fetch(STEAM_API_URL),
+            fetch(STEAM_LEVEL_URL)
+        ]);
+
+        if (!gamesRes.ok) throw new Error(`HTTP ${gamesRes.status}`);
 
         /** @type {import("../api/src/index").SteamResult} */
-        const data = await response.json();
-        updateSteamStats(data.topGames.length, data.totalHours, data.lastPlayedGame);
+        const data = await gamesRes.json();
+        const steamLevel = levelRes.ok ? ((await levelRes.json()).steamLevel ?? null) : null;
+
+        updateSteamStats(data.gameCount, data.totalHours, data.lastPlayedGame, steamLevel, data.topGames);
     } catch (err) {
         console.error('Steam API error:', err);
         setSteamError();
@@ -20,14 +25,15 @@ async function fetchSteamGames() {
     }
 }
 
-function updateSteamStats(gameCount, totalHours, lastPlayedGame) {
-    const hoursEl = document.getElementById('steam-hours');
-    const gamesEl = document.getElementById('steam-games');
-    const lastPlayedEl = document.getElementById('steam-last-played');
+function updateSteamStats(gameCount, totalHours, lastPlayedGame, steamLevel, topGames) {
+    const hoursEl        = document.getElementById('steam-hours');
+    const gamesEl        = document.getElementById('steam-games');
+    const lastPlayedEl   = document.getElementById('steam-last-played');
     const lastPlayedLabel = document.getElementById('steam-last-played-label');
+    const levelEl        = document.getElementById('steam-level-value');
 
     if (hoursEl) hoursEl.textContent = totalHours ? `${totalHours.toLocaleString()}+` : '—';
-    if (gamesEl) gamesEl.textContent = gameCount ? `${gameCount}+` : '—';
+    if (gamesEl) gamesEl.textContent = gameCount  ? `${gameCount}+`  : '—';
 
     if (lastPlayedGame && lastPlayedEl) {
         const lastPlayedDate = new Date(lastPlayedGame.lastPlayed * 1000);
@@ -43,13 +49,39 @@ function updateSteamStats(gameCount, totalHours, lastPlayedGame) {
         lastPlayedEl.textContent = lastPlayedGame.name;
         if (lastPlayedLabel) lastPlayedLabel.textContent = `Last played ${timeAgo}`;
     } else {
-        if (lastPlayedEl) lastPlayedEl.textContent = '—';
+        if (lastPlayedEl)    lastPlayedEl.textContent = '—';
         if (lastPlayedLabel) lastPlayedLabel.textContent = 'Last Played';
+    }
+
+    // Steam level badge
+    if (levelEl) {
+        levelEl.textContent = steamLevel != null ? steamLevel : '—';
+        levelEl.classList.remove('loading');
+    }
+
+    // Top 3 most-played games
+    const topGamesContainer = document.getElementById('steam-top-games');
+    if (topGamesContainer && Array.isArray(topGames) && topGames.length > 0) {
+        topGamesContainer.innerHTML = topGames.map((game, i) => `
+            <div class="top-game-row">
+                <span class="top-game-rank">#${i + 1}</span>
+                <span class="top-game-name">${escapeHtml(game.name)}</span>
+                <span class="top-game-hours">${game.hours.toLocaleString()}h</span>
+            </div>
+        `).join('');
     }
 }
 
+function escapeHtml(str) {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
 function setSteamLoading(isLoading) {
-    const ids = ['steam-hours', 'steam-games', 'steam-last-played'];
+    const ids = ['steam-hours', 'steam-games', 'steam-last-played', 'steam-level-value'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) {
@@ -60,7 +92,7 @@ function setSteamLoading(isLoading) {
 }
 
 function setSteamError() {
-    ['steam-hours', 'steam-games', 'steam-last-played'].forEach(id => {
+    ['steam-hours', 'steam-games', 'steam-last-played', 'steam-level-value'].forEach(id => {
         const el = document.getElementById(id);
         if (el) { el.textContent = '—'; el.classList.remove('loading'); }
     });

--- a/src/styles.css
+++ b/src/styles.css
@@ -677,3 +677,158 @@ body {
     display: none;
   }
 }
+
+/* ── Profile Meta Row ────────────────────────────────────────── */
+.profile-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.6rem;
+}
+
+.profile-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.profile-meta-item i {
+  color: var(--pink);
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
+.profile-meta-sep {
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  user-select: none;
+}
+
+#osu-title-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 99px;
+  background: var(--pink-subtle);
+  border: 1px solid var(--border);
+  color: var(--pink);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin-right: 0.2rem;
+}
+
+/* ── Steam Level Badge ───────────────────────────────────────── */
+.steam-level-item {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.steam-level-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1b2838 0%, #2a475e 100%);
+  border: 2px solid #c7d5e0;
+  box-shadow: 0 0 12px rgba(199, 213, 224, 0.15);
+}
+
+.steam-level-number {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #c7d5e0;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+/* ── Steam card top / top-games panel ───────────────────────── */
+.steam-card-top {
+  border-radius: var(--radius) var(--radius) 0 0;
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: none;
+}
+
+.steam-top-games-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.steam-top-games-header {
+  padding: 0.5rem 1.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.top-game-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.15s;
+}
+
+.top-game-row:last-child {
+  border-bottom: none;
+}
+
+.top-game-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.top-game-rank {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--pink);
+  width: 1.8rem;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.top-game-name {
+  flex: 1;
+  font-size: 0.88rem;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.top-game-hours {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+@media (max-width: 700px) {
+  .steam-level-item {
+    flex: unset;
+    min-width: 40%;
+    padding: 0;
+  }
+
+  .steam-top-games-header,
+  .top-game-row {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
+}


### PR DESCRIPTION
- Fix getOsuToken(): add response.ok check so OAuth errors are thrown instead of silently caching "undefined" as the bearer token
- Extend OsuResult with followerCount, joinDate, rankedScore, title; render them in a new profile-meta-row below the profile tags
- Extend SteamResult: add explicit gameCount, change topGames to { name, hours }[] (top 3 only); bump cache key to steam:profile:v2
- steam-api.js: parallel-fetch /my-steam + /my-steam-level; render Steam level badge and top-3 most-played games panel
- CSS: profile meta row, osu! title pill badge, Steam level circle badge, steam-top-games-card merged with steam-stats-card

https://claude.ai/code/session_018K4MCKH8Gm68VVBvfXB1pU