### PR TITLE
Fix nya.jpg 404, handle old topGames format defensively

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
     <div class="profile-bar">
       <div class="profile-bar-inner">
         <div class="avatar-section">
-          <img class="profile-avatar" id="profile-avatar" src="/static/nya.jpg" alt="nyannoying" />
+          <img class="profile-avatar" id="profile-avatar" src="/nya.jpg" alt="nyannoying" />
         </div>
         <div class="profile-info">
           <div class="username-row">

--- a/src/steam-api.js
+++ b/src/steam-api.js
@@ -59,16 +59,18 @@ function updateSteamStats(gameCount, totalHours, lastPlayedGame, steamLevel, top
         levelEl.classList.remove('loading');
     }
 
-    // Top 3 most-played games
+    // Top 3 most-played games — handle both {name,hours}[] and legacy string[]
     const topGamesContainer = document.getElementById('steam-top-games');
     if (topGamesContainer && Array.isArray(topGames) && topGames.length > 0) {
-        topGamesContainer.innerHTML = topGames.map((game, i) => `
-            <div class="top-game-row">
+        topGamesContainer.innerHTML = topGames.slice(0, 3).map((game, i) => {
+            const name  = typeof game === 'string' ? game : (game.name  ?? '—');
+            const hours = typeof game === 'string' ? null  : (game.hours ?? null);
+            return `<div class="top-game-row">
                 <span class="top-game-rank">#${i + 1}</span>
-                <span class="top-game-name">${escapeHtml(game.name)}</span>
-                <span class="top-game-hours">${game.hours.toLocaleString()}h</span>
-            </div>
-        `).join('');
+                <span class="top-game-name">${escapeHtml(name)}</span>
+                ${hours != null ? `<span class="top-game-hours">${hours.toLocaleString()}h</span>` : ''}
+            </div>`;
+        }).join('');
     }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  publicDir: 'static',
   server: {
     open: "/index.html",
   },


### PR DESCRIPTION
- vite.config.js: set publicDir to 'static' so Vite serves static/ assets at root (nya.jpg was 404 because Vite defaults to public/)
- src/index.html: change avatar src from /static/nya.jpg to /nya.jpg
- src/steam-api.js: top-games renderer handles both legacy string[] and new {name,hours}[] shapes until Worker is redeployed

https://claude.ai/code/session_018K4MCKH8Gm68VVBvfXB1pU