### PR TITLE
Redesign site as personal hub with blog/notes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- HTML Meta Tags -->
     <title>nyannoying</title>
-    <meta name="description" content="nyannoying's corner — osu! player, steam enjoyer">
+    <meta name="description" content="nyannoying's corner — music, games, and whatever else">
 
     <!-- Facebook Meta Tags -->
     <meta property="og:url" content="https://nyannoying.de">
     <meta property="og:type" content="website">
     <meta property="og:title" content="nyannoying">
-    <meta property="og:description" content="nyannoying's corner — osu! player, steam enjoyer">
+    <meta property="og:description" content="nyannoying's corner — music, games, and whatever else">
     <meta property="og:image" content="/static/nya.jpg">
 
     <!-- Twitter Meta Tags -->
@@ -20,7 +20,7 @@
     <meta property="twitter:domain" content="nyannoying.de">
     <meta property="twitter:url" content="https://nyannoying.de">
     <meta name="twitter:title" content="nyannoying">
-    <meta name="twitter:description" content="nyannoying's corner — osu! player, steam enjoyer">
+    <meta name="twitter:description" content="nyannoying's corner — music, games, and whatever else">
     <meta name="twitter:image" content="/static/nya.jpg">
 
     <!-- Meta Tags Generated via https://www.opengraph.xyz -->

--- a/src/index.html
+++ b/src/index.html
@@ -1,17 +1,13 @@
-<div class="osu-page">
+<div class="site-wrap">
 
   <!-- Navbar -->
-  <nav class="osu-nav">
+  <nav class="site-nav">
     <div class="nav-inner">
       <a href="#" class="nav-brand">
-        <svg class="osu-cookie" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="14" cy="14" r="12.5" stroke="#ff66aa" stroke-width="2"/>
-          <circle cx="14" cy="14" r="7" stroke="#ff66aa" stroke-width="1.5"/>
-          <circle cx="14" cy="14" r="2.5" fill="#ff66aa"/>
-        </svg>
-        <span>osu!</span>
+        <span class="nav-tilde">~</span>
+        <span>nyannoying</span>
       </a>
-      <span class="nav-tagline">nyannoying's corner</span>
+      <span class="nav-tagline">nyannoying.de</span>
     </div>
   </nav>
 
@@ -31,10 +27,13 @@
           <p class="profile-bio">I am a idiot, lets hang out</p>
           <div class="profile-tags">
             <span class="profile-tag">
-              <i class="fas fa-music"></i> osu! player
+              <i class="fas fa-music"></i> music enjoyer
             </span>
             <span class="profile-tag">
-              <i class="fab fa-steam"></i> steam enjoyer
+              <i class="fas fa-gamepad"></i> gamer
+            </span>
+            <span class="profile-tag">
+              <i class="fas fa-code"></i> amateur dev
             </span>
           </div>
           <div class="profile-meta-row" id="profile-meta-row" style="display:none;">
@@ -61,6 +60,15 @@
 
   <!-- Page Content -->
   <div class="content-area">
+
+    <!-- Blog / Notes -->
+    <section class="content-section">
+      <h2 class="section-heading">
+        <i class="fas fa-pencil-alt section-icon"></i>
+        Notes
+      </h2>
+      <div class="posts-list" id="posts-list"></div>
+    </section>
 
     <!-- osu! Stats -->
     <section class="content-section">

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,12 @@
 import data from "./index.html?raw"
 import "./styles.css"
-import "./script.js"
+import { renderPosts } from "./script.js"
 import "./osu-api.js"
 import "./steam-api.js"
+import { posts } from "./posts.js"
 
 document.querySelector("#site").innerHTML = data;
+
+document.addEventListener('DOMContentLoaded', () => {
+    renderPosts(posts);
+});

--- a/src/posts.js
+++ b/src/posts.js
@@ -1,0 +1,9 @@
+export const posts = [
+    {
+        id: 'new-site',
+        title: 'new site, who dis',
+        date: '2026-05-10',
+        tags: ['meta'],
+        content: `finally got around to making this place something i actually like. the old version was just a stats page for osu! and steam which felt a bit too one-dimensional.\n\nwanted somewhere i could write stuff down occasionally — music i'm into, things i'm building, random thoughts. no promises on frequency but hey, it exists now.`
+    }
+]

--- a/src/script.js
+++ b/src/script.js
@@ -17,3 +17,47 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+export function renderPosts(posts) {
+    const container = document.getElementById('posts-list');
+    if (!container) return;
+
+    if (!posts || posts.length === 0) {
+        container.innerHTML = '<p class="posts-empty">nothing here yet</p>';
+        return;
+    }
+
+    container.innerHTML = posts.map(post => {
+        const tags = (post.tags || []).map(t =>
+            `<span class="post-tag">${escapeHtml(t)}</span>`
+        ).join('');
+
+        return `<article class="post-card" data-post-id="${escapeHtml(post.id)}">
+            <div class="post-header">
+                <h3 class="post-title">${escapeHtml(post.title)}</h3>
+                <div class="post-meta">
+                    ${tags ? `<div class="post-tags">${tags}</div>` : ''}
+                    <span class="post-date">${escapeHtml(post.date)}</span>
+                    <i class="fas fa-chevron-down post-chevron"></i>
+                </div>
+            </div>
+            <div class="post-body">
+                <p class="post-content">${escapeHtml(post.content)}</p>
+            </div>
+        </article>`;
+    }).join('');
+
+    container.querySelectorAll('.post-header').forEach(header => {
+        header.addEventListener('click', () => {
+            header.closest('.post-card').classList.toggle('expanded');
+        });
+    });
+}
+
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-/* osu!-inspired design system */
+/* site design system */
 :root {
   --pink:          #ff66aa;
   --pink-dark:     #cc3388;
@@ -30,7 +30,7 @@ body {
 }
 
 /* ── Navbar ─────────────────────────────────────────────────── */
-.osu-nav {
+.site-nav {
   position: sticky;
   top: 0;
   z-index: 100;
@@ -55,18 +55,18 @@ body {
 .nav-brand {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.4rem;
   text-decoration: none;
   color: var(--pink);
   font-weight: 700;
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   letter-spacing: -0.02em;
 }
 
-.osu-cookie {
-  width: 26px;
-  height: 26px;
-  flex-shrink: 0;
+.nav-tilde {
+  font-size: 1.4rem;
+  line-height: 1;
+  opacity: 0.85;
 }
 
 .nav-tagline {
@@ -539,6 +539,112 @@ body {
 .link-card.youtube:hover { border-color: #ff4444; }
 .link-card.twitch:hover { border-color: #9146ff; }
 .link-card.github:hover { border-color: #e4e4e4; }
+
+/* ── Blog / Notes ────────────────────────────────────────────── */
+.posts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.post-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--pink);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(16px);
+  animation: fade-up 0.45s ease forwards;
+  animation-delay: 0.1s;
+}
+
+.post-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  cursor: pointer;
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.post-header:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.post-title {
+  flex: 1;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.post-date {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.post-tags {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.post-tag {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: 99px;
+  background: var(--pink-subtle);
+  border: 1px solid var(--border);
+  color: var(--pink);
+  letter-spacing: 0.03em;
+}
+
+.post-chevron {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+
+.post-card.expanded .post-chevron {
+  transform: rotate(180deg);
+}
+
+.post-body {
+  display: none;
+  padding: 0 1.5rem 1.25rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.post-card.expanded .post-body {
+  display: block;
+}
+
+.post-content {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  line-height: 1.75;
+  white-space: pre-wrap;
+  margin: 0.85rem 0 0;
+}
+
+.posts-empty {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  padding: 1rem 0;
+}
 
 /* ── Footer ──────────────────────────────────────────────────── */
 .osu-footer {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace osu!-focused nav branding with a clean `~ nyannoying` identity
- Add a **Notes** section at the top of the page — expandable post cards rendered from `src/posts.js`
- Update profile tags from "osu! player / steam enjoyer" to "music enjoyer / gamer / amateur dev"
- Update site meta description to be more general
- Gaming stats (osu! + Steam) stay intact below the blog section

## How to add posts

Edit `src/posts.js` and add an object to the array:

```js
{
  id: 'my-post',        // unique slug
  title: 'post title',
  date: '2026-05-10',
  tags: ['music'],      // optional
  content: `...`        // supports newlines
}
```

## Test plan

- [ ] Run `pnpm dev` and verify the Notes section appears above the gaming stats
- [ ] Click a post card to expand/collapse it
- [ ] Verify nav shows `~ nyannoying` branding
- [ ] Verify profile tags updated
- [ ] Verify osu! and Steam stats still load correctly

https://claude.ai/code/session_018cdkRZuUHgA8rMbNefbJ9n
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018cdkRZuUHgA8rMbNefbJ9n)_